### PR TITLE
cmd/extract-notes: Implement note extraction per version

### DIFF
--- a/cmd/changelog-extract-notes/main.go
+++ b/cmd/changelog-extract-notes/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/hashicorp/go-changelog/parser"
+)
+
+func main() {
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+
+	var extractVersion, changelogPath string
+	flag.StringVar(&changelogPath, "path", filepath.Join(wd, "CHANGELOG.md"), "path to the changelog file")
+	flag.StringVar(&extractVersion, "version", "", "version to extract changelog for (e.g. 1.0.0)")
+	flag.Parse()
+
+	if extractVersion == "" {
+		fmt.Fprintf(os.Stderr, "Must specify version\n\n")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	f, err := os.Open(changelogPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to open changelog file: %s", err)
+		os.Exit(1)
+	}
+
+	b, err := ioutil.ReadAll(f)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to read changelog file: %s", err)
+		os.Exit(1)
+	}
+
+	sp := parser.NewSectionParser(b)
+	s, err := sp.Section(extractVersion)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	_, err = os.Stdout.Write(s.Body)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/hashicorp/go-changelog
 go 1.13
 
 require (
+	github.com/google/go-cmp v0.3.0
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d

--- a/parser/errors.go
+++ b/parser/errors.go
@@ -1,0 +1,19 @@
+package parser
+
+import "fmt"
+
+type VersionNotFoundErr struct {
+	Version string
+}
+
+func (e *VersionNotFoundErr) Is(target error) bool {
+	tErr, ok := target.(*VersionNotFoundErr)
+	if !ok {
+		return false
+	}
+	return tErr.Version == e.Version
+}
+
+func (e *VersionNotFoundErr) Error() string {
+	return fmt.Sprintf("version %s not found", e.Version)
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,0 +1,116 @@
+package parser
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+)
+
+var (
+	defaultSectionReFmt = `(?s)(?P<header>## %s[^\n]*)
+(?P<body>.+?)
+(## .+|$)`
+	headerMatchName = "header"
+	bodyMatchName   = "body"
+)
+
+type SectionParser struct {
+	RegexpFormat string
+	content []byte
+}
+
+func NewSectionParser(b []byte) *SectionParser {
+	return &SectionParser{
+		RegexpFormat: defaultSectionReFmt,
+		content: b,
+	}
+}
+
+type SectionRange struct {
+	HeaderRange *ByteRange
+	BodyRange   *ByteRange
+}
+
+type ByteRange struct {
+	From, To int
+}
+
+func (p *SectionParser) regexpFormat() string {
+	if p.RegexpFormat == "" {
+		return defaultSectionReFmt
+	}
+	return p.RegexpFormat
+}
+
+func (p *SectionParser) regexp(v string) (*regexp.Regexp, error) {
+	escapedVersion := regexp.QuoteMeta(v)
+	return regexp.Compile(fmt.Sprintf(p.regexpFormat(), escapedVersion))
+}
+
+func (p *SectionParser) SectionRange(v string) (*SectionRange, error) {
+	re, err := p.regexp(v)
+	if err != nil {
+		return nil, err
+	}
+
+	loc := re.FindSubmatchIndex(p.content)
+	if loc == nil {
+		return nil, &VersionNotFoundErr{v}
+	}
+
+	headerIdx, err := findSubexpIndexes(re, headerMatchName)
+	if err != nil {
+		return nil, err
+	}
+
+	bodyIdx, err := findSubexpIndexes(re, bodyMatchName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SectionRange{
+		HeaderRange: &ByteRange{
+			From: loc[headerIdx.from],
+			To:   loc[headerIdx.to],
+		},
+		BodyRange: &ByteRange{
+			From: loc[bodyIdx.from],
+			To:   loc[bodyIdx.to],
+		},
+	}, nil
+}
+
+type index struct {
+	from, to int
+}
+
+func findSubexpIndexes(re *regexp.Regexp, name string) (*index, error) {
+	for i, seName := range re.SubexpNames() {
+		if seName == name {
+			from := i * 2
+			return &index{from, from + 1}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("subexpression %q not found", name)
+}
+
+type Section struct {
+	Header []byte
+	Body   []byte
+}
+
+func (p *SectionParser) Section(v string) (*Section, error) {
+	sr, err := p.SectionRange(v)
+	if err != nil {
+		return nil, err
+	}
+
+	headerRng := sr.HeaderRange
+	bodyRng := sr.BodyRange
+
+	return &Section{
+		Header: bytes.TrimSpace(p.content[headerRng.From:headerRng.To]),
+		Body:   bytes.TrimSpace(p.content[bodyRng.From:bodyRng.To]),
+	}, nil
+}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1,0 +1,96 @@
+package parser
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestParser_Section(t *testing.T) {
+	testCases := []struct {
+		name    string
+		content string
+		version string
+
+		expectedSection *Section
+		expectedErr     error
+	}{
+		{
+			"empty log",
+			"",
+			"0.12.0",
+			nil,
+			&VersionNotFoundErr{"0.12.0"},
+		},
+		{
+			"version not found",
+			`## 0.11.0
+
+something
+
+## 0.10.0
+
+testing
+`,
+			"0.12.0",
+			nil,
+			&VersionNotFoundErr{"0.12.0"},
+		},
+		{
+			"matching unreleased version",
+			`## 0.12.0 (Unreleased)
+
+something
+
+## 0.11.0
+
+testing
+`,
+			"0.12.0",
+			&Section{
+				Header: []byte("## 0.12.0 (Unreleased)"),
+				Body:   []byte("something"),
+			},
+			nil,
+		},
+		{
+			"matching released version - top",
+			`## 0.12.0
+matching text
+with newline
+
+## 0.11.99
+
+ - something
+ - else
+`,
+			"0.12.0",
+			&Section{
+				Header: []byte("## 0.12.0"),
+				Body: []byte(`matching text
+with newline`),
+			},
+			nil,
+		},
+	}
+	for i, tc := range testCases {
+		t.Run(fmt.Sprintf("%d-%s", i, tc.name), func(t *testing.T) {
+			p := NewSectionParser([]byte(tc.content))
+			s, err := p.Section(tc.version)
+			if err == nil && tc.expectedErr != nil {
+				t.Fatalf("expected error: %s", tc.expectedErr.Error())
+			}
+
+			if !errors.Is(err, tc.expectedErr) {
+				diff := cmp.Diff(tc.expectedErr, err)
+				t.Fatalf("error doesn't match: %s", diff)
+			}
+
+			if diff := cmp.Diff(tc.expectedSection, s); diff != "" {
+				t.Fatalf("parsed section don't match: %s", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Use case

Some projects may not be at such a scale that they would want or need to adopt any changelog generation mechanism. They may however still benefit from some automation when uploading the relevant changelog at release time, for example to GitHub Releases.

The output is _assumed_ to match the output of `changelog-build`, given the default template and default regular expression in the parser.

## Implementation Details

The parser was designed with some other future use cases in mind - e.g.

 - `SectionRange().BodyRange` can be used to identify the range where notes are and replace the relevant section of changelog; This allows regenerating an "unreleased" changelog straight after merging a PR.
 - `SectionRange().HeaderRange` can be used to identify the range of header and replace `(Unreleased)` with a release date
   - possibly even automate Changelog updates in [Vagrant's style](https://github.com/hashicorp/vagrant/blob/master/CHANGELOG.md#next-version-unreleased) - i.e. replace `Next version (Unreleased)` with `VERSION (RELEASE-DATE)`

The parser is as accurate as the regular expression that drives it, but I think the default one is flexible enough (basically just assumes valid Markdown `##` header, no particular versioning) to cover format that most HashiCorp projects use for their Changelogs.

## Usage

```
terraform-provider-google $ changelog-extract-notes -version 3.15.0
```
```
FEATURES:
...
IMPROVEMENTS:
...
BUG FIXES:
...
```

This also allows easy plugging into [GoReleaser's interface](https://goreleaser.com/customization/#custom-release-notes), e.g.

```
$ goreleaser --release-notes <(changelog-extract-notes -version $GIT_TAG)
```