### PR TITLE
add stringHasPrefix to template

### DIFF
--- a/cmd/changelog-build/main.go
+++ b/cmd/changelog-build/main.go
@@ -85,6 +85,9 @@ func main() {
 			}
 			return res
 		},
+		"stringHasPrefix": func(s, prefix string) bool {
+			return strings.HasPrefix(s, prefix)
+		},
 	})
 	tmpl, err = tmpl.ParseFiles(noteTmpl)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/hashicorp/go-changelog/issues/3.
This is something we want to use in consul to determine if a link should
be displayed or not. We plan to prefix changelog entry files that
don't generate a link to an issue with `.`.

Eg `.1234.txt` with this content:

~~~
```release-note:enhancement
Added the `bar` interface.
```
~~~

and this note template:

```
{{- define "note" -}}
{{.Body}}{{if not stringHasPrefix .Issue "."}} [[GH-{{- .Issue -}}](https://github.com/hashicorp/consul/issues/{{- .Issue -}})]{{end}}
{{- end -}}
```

wouldn't generate a link.