### PR TITLE
cmd/changelog-pr-body-check: Use %s verbs instead of %w in log.Fatalf() calls

### DIFF
--- a/cmd/changelog-pr-body-check/main.go
+++ b/cmd/changelog-pr-body-check/main.go
@@ -19,7 +19,7 @@ func main() {
 	pr := os.Args[1]
 	prNo, err := strconv.Atoi(pr)
 	if err != nil {
-		log.Fatalf("Error parsing PR %q as a number: %w", pr, err)
+		log.Fatalf("Error parsing PR %q as a number: %s", pr, err)
 	}
 
 	owner := os.Getenv("GITHUB_OWNER")
@@ -46,7 +46,7 @@ func main() {
 	pullRequest, _, err := client.PullRequests.Get(ctx, owner, repo, prNo)
 	if err != nil {
 		log.Fatalf("Error retrieving pull request github.com/"+
-			"%s/%s/%d: %w", owner, repo, prNo, err)
+			"%s/%s/%d: %s", owner, repo, prNo, err)
 	}
 	entry := changelog.Entry{
 		Issue: pr,
@@ -67,7 +67,7 @@ func main() {
 			})
 		if err != nil {
 			log.Fatalf("Error creating pull request comment on"+
-				" github.com/%s/%s/%d: %w", owner, repo, prNo,
+				" github.com/%s/%s/%d: %s", owner, repo, prNo,
 				err)
 		}
 		os.Exit(1)
@@ -109,7 +109,7 @@ func main() {
 			})
 		if err != nil {
 			log.Fatalf("Error creating pull request comment on"+
-				" github.com/%s/%s/%d: %w", owner, repo, prNo,
+				" github.com/%s/%s/%d: %s", owner, repo, prNo,
 				err)
 		}
 		os.Exit(1)


### PR DESCRIPTION
Closes #10

Previously (Go 1.16):

```console
$ go version
go version go1.16.3 darwin/amd64
$ go test ./cmd/changelog-pr-body-check
# github.com/hashicorp/go-changelog/cmd/changelog-pr-body-check
cmd/changelog-pr-body-check/main.go:22:3: Fatalf call has error-wrapping directive %w
cmd/changelog-pr-body-check/main.go:48:3: Fatalf call has error-wrapping directive %w
cmd/changelog-pr-body-check/main.go:69:4: Fatalf call has error-wrapping directive %w
cmd/changelog-pr-body-check/main.go:111:4: Fatalf call has error-wrapping directive %w
```

Now:

```console
go test ./cmd/changelog-pr-body-check
?       github.com/hashicorp/go-changelog/cmd/changelog-pr-body-check   [no test files]
```