### PR TITLE
Adding sort by date to go-changelog

### DIFF
--- a/cmd/changelog-build/main.go
+++ b/cmd/changelog-build/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	tmpl := template.New(filepath.Base(changelogTmpl)).Funcs(template.FuncMap{
 		"sort": func(in []changelog.Note) []changelog.Note {
-			sort.Slice(in, changelog.SortNotes(in))
+			sort.Slice(in, changelog.SortNotes(in, sortByDate))
 			return in
 		},
 		"combineTypes": func(in ...[]changelog.Note) []changelog.Note {
@@ -114,15 +114,15 @@ func main() {
 		if strings.HasSuffix(entry.Issue, ".txt") {
 			entry.Issue = strings.TrimSuffix(entry.Issue, ".txt")
 		}
-		notes = append(notes, changelog.NotesFromEntry(entry)...)
+		notes = append(notes, changelog.NotesFromEntry(entry, sortByDate)...)
 	}
 	for _, note := range notes {
 		notesByType[note.Type] = append(notesByType[note.Type], note)
 	}
 	for _, n := range notesByType {
-		sort.Slice(n, changelog.SortNotes(n))
+		sort.Slice(n, changelog.SortNotes(n, sortByDate))
 	}
-	sort.Slice(notes, changelog.SortNotes(notes))
+	sort.Slice(notes, changelog.SortNotes(notes, sortByDate))
 	type renderData struct {
 		Notes       []changelog.Note
 		NotesByType map[string][]changelog.Note

--- a/cmd/changelog-build/main.go
+++ b/cmd/changelog-build/main.go
@@ -19,12 +19,14 @@ func main() {
 		os.Exit(1)
 	}
 	var lastRelease, thisRelease, repoDir, entriesDir, noteTmpl, changelogTmpl string
+	var sortByDate bool
 	flag.StringVar(&lastRelease, "last-release", "", "a git ref to the last commit in the previous release")
 	flag.StringVar(&thisRelease, "this-release", "", "a git ref to the last commit to include in this release")
 	flag.StringVar(&repoDir, "git-dir", pwd, "the directory of the git repo being released")
 	flag.StringVar(&entriesDir, "entries-dir", "", "the directory within the repo containing changelog entry files")
 	flag.StringVar(&noteTmpl, "note-template", "", "the path of the file holding the template to use for each item in the changelog")
 	flag.StringVar(&changelogTmpl, "changelog-template", "", "the path of the file holding the template to use for the entire changelog")
+	flag.BoolVar(&sortByDate, "sort-by-date", false, "sort the entries by date instead of PR number on txt files")
 	flag.Parse()
 
 	if lastRelease == "" {
@@ -101,7 +103,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	entries, err := changelog.Diff(repoDir, lastRelease, thisRelease, entriesDir)
+	entries, err := changelog.Diff(repoDir, lastRelease, thisRelease, entriesDir, sortByDate)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/changelog-pr-body-check/main.go
+++ b/cmd/changelog-pr-body-check/main.go
@@ -52,7 +52,7 @@ func main() {
 		Issue: pr,
 		Body:  pullRequest.GetBody(),
 	}
-	notes := changelog.NotesFromEntry(entry, false)
+	notes := changelog.NotesFromEntry(entry)
 	if len(notes) < 1 {
 		log.Printf("no changelog entry found in %s: %s", entry.Issue,
 			string(entry.Body))

--- a/cmd/changelog-pr-body-check/main.go
+++ b/cmd/changelog-pr-body-check/main.go
@@ -52,7 +52,7 @@ func main() {
 		Issue: pr,
 		Body:  pullRequest.GetBody(),
 	}
-	notes := changelog.NotesFromEntry(entry)
+	notes := changelog.NotesFromEntry(entry, false)
 	if len(notes) < 1 {
 		log.Printf("no changelog entry found in %s: %s", entry.Issue,
 			string(entry.Body))

--- a/entry.go
+++ b/entry.go
@@ -4,6 +4,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
+	"time"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -14,9 +15,17 @@ import (
 type Entry struct {
 	Issue string
 	Body  string
+	Date  time.Time
+	Hash  string
 }
 
-func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
+type changelog struct {
+	content []byte
+	hash    string
+	date    time.Time
+}
+
+func Diff(repo, ref1, ref2, dir string, sortByDate bool) ([]Entry, error) {
 	r, err := git.Clone(memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL: repo,
 	})
@@ -46,9 +55,10 @@ func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
 	if err != nil {
 		return nil, err
 	}
-	entriesAfter := make(map[string][]byte, len(entriesAfterFI))
+	entriesAfter := make(map[string]changelog, len(entriesAfterFI))
 	for _, i := range entriesAfterFI {
-		f, err := wt.Filesystem.Open(filepath.Join(dir, i.Name()))
+		fp := filepath.Join(dir, i.Name())
+		f, err := wt.Filesystem.Open(fp)
 		if err != nil {
 			return nil, err
 		}
@@ -57,7 +67,15 @@ func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
 		if err != nil {
 			return nil, err
 		}
-		entriesAfter[i.Name()] = contents
+		log, err := r.Log(&git.LogOptions{FileName: &fp})
+		if err != nil {
+			return nil, err
+		}
+		lastChange, err := log.Next()
+		if err != nil {
+			return nil, err
+		}
+		entriesAfter[i.Name()] = changelog{content: contents, date: lastChange.Author.When, hash: lastChange.Hash.String()}
 	}
 	if rev1 != nil {
 		err = wt.Checkout(&git.CheckoutOptions{
@@ -73,14 +91,23 @@ func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
 		}
 	}
 	entries := make([]Entry, 0, len(entriesAfter))
-	for name, contents := range entriesAfter {
+	for name, cl := range entriesAfter {
 		entries = append(entries, Entry{
 			Issue: name,
-			Body:  string(contents),
+			Body:  string(cl.content),
+			Date:  cl.date,
+			Hash:  cl.hash,
 		})
 	}
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Issue < entries[j].Issue
-	})
+	if sortByDate {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Date.Before(entries[j].Date)
+		})
+	} else {
+		sort.Slice(entries, func(i, j int) bool {
+			return entries[i].Issue < entries[j].Issue
+		})
+	}
+
 	return entries, nil
 }

--- a/entry.go
+++ b/entry.go
@@ -25,7 +25,7 @@ type changelog struct {
 	date    time.Time
 }
 
-func Diff(repo, ref1, ref2, dir string, sortByDate bool) ([]Entry, error) {
+func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
 	r, err := git.Clone(memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL: repo,
 	})
@@ -99,15 +99,9 @@ func Diff(repo, ref1, ref2, dir string, sortByDate bool) ([]Entry, error) {
 			Hash:  cl.hash,
 		})
 	}
-	if sortByDate {
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].Date.Before(entries[j].Date)
-		})
-	} else {
-		sort.Slice(entries, func(i, j int) bool {
-			return entries[i].Issue < entries[j].Issue
-		})
-	}
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Issue < entries[j].Issue
+	})
 
 	return entries, nil
 }

--- a/note.go
+++ b/note.go
@@ -10,6 +10,7 @@ type Note struct {
 	Type  string
 	Body  string
 	Issue string
+	Hash  string
 }
 
 var textInBodyREs = []*regexp.Regexp{
@@ -53,6 +54,7 @@ func NotesFromEntry(entry Entry) []Note {
 				Type:  typ,
 				Body:  note,
 				Issue: entry.Issue,
+				Hash:  entry.Hash,
 			})
 		}
 	}

--- a/note.go
+++ b/note.go
@@ -74,7 +74,7 @@ func SortNotes(res []Note, sortByDate bool) func(i, j int) bool {
 		} else if sortByDate && res[i].Date.Before(res[j].Date) {
 			return false
 		} else if sortByDate && res[i].Date.After(res[j].Date) {
-			return false
+			return true
 		} else if res[i].Body < res[j].Body {
 			return true
 		} else if res[j].Body < res[i].Body {

--- a/note.go
+++ b/note.go
@@ -22,7 +22,7 @@ var textInBodyREs = []*regexp.Regexp{
 	regexp.MustCompile("(?ms)^```releasenote:(?P<type>[^\r\n]*)\r?\n?(?P<note>.*?)\r?\n?```"),
 }
 
-func NotesFromEntry(entry Entry, sortByDate bool) []Note {
+func NotesFromEntry(entry Entry) []Note {
 	var res []Note
 	for _, re := range textInBodyREs {
 		matches := re.FindAllStringSubmatch(entry.Body, -1)
@@ -61,20 +61,16 @@ func NotesFromEntry(entry Entry, sortByDate bool) []Note {
 			})
 		}
 	}
-	sort.Slice(res, SortNotes(res, sortByDate))
+	sort.Slice(res, SortNotes(res))
 	return res
 }
 
-func SortNotes(res []Note, sortByDate bool) func(i, j int) bool {
+func SortNotes(res []Note) func(i, j int) bool {
 	return func(i, j int) bool {
 		if res[i].Type < res[j].Type {
 			return true
 		} else if res[j].Type < res[i].Type {
 			return false
-		} else if sortByDate && res[i].Date.Before(res[j].Date) {
-			return false
-		} else if sortByDate && res[i].Date.After(res[j].Date) {
-			return true
 		} else if res[i].Body < res[j].Body {
 			return true
 		} else if res[j].Body < res[i].Body {


### PR DESCRIPTION
Add ability to have entries sorted by date rather than file name.  This allows commits made directly to master to be tagged if necessary.

Also include the hash for notes to render hashes if necessary.