### PR TITLE
Traverse git log concurrently

### DIFF
--- a/cmd/changelog-build/main.go
+++ b/cmd/changelog-build/main.go
@@ -124,11 +124,12 @@ func main() {
 	}
 	var notes []changelog.Note
 	notesByType := map[string][]changelog.Note{}
-	for _, entry := range entries {
+	for i := 0; i < entries.Len(); i++ {
+		entry := entries.Get(i)
 		if strings.HasSuffix(entry.Issue, ".txt") {
 			entry.Issue = strings.TrimSuffix(entry.Issue, ".txt")
 		}
-		notes = append(notes, changelog.NotesFromEntry(entry)...)
+		notes = append(notes, changelog.NotesFromEntry(*entry)...)
 	}
 	for _, note := range notes {
 		notesByType[note.Type] = append(notesByType[note.Type], note)

--- a/cmd/changelog-build/main.go
+++ b/cmd/changelog-build/main.go
@@ -3,11 +3,16 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 	"text/template"
+
+	// needed to create flame graphs
+	"net/http"
+	_ "net/http/pprof"
 
 	"github.com/hashicorp/go-changelog"
 )
@@ -68,6 +73,11 @@ func main() {
 		flag.Usage()
 		os.Exit(1)
 	}
+
+	go func() {
+		log.Println("Starting pprof server on localhost:8080...")
+		log.Println(http.ListenAndServe("localhost:8080", nil))
+	}()
 
 	tmpl := template.New(filepath.Base(changelogTmpl)).Funcs(template.FuncMap{
 		"sort": func(in []changelog.Note) []changelog.Note {

--- a/entry.go
+++ b/entry.go
@@ -171,12 +171,12 @@ func Diff(repo, ref1, ref2, dir string) (*EntryList, error) {
 				fp := filepath.Join(dir, n)
 				f, err := wt.Filesystem.Open(fp)
 				if err != nil {
-					return fmt.Errorf("error opening file at %s: %w", name, err)
+					return fmt.Errorf("error opening file at %s: %w", n, err)
 				}
 				contents, err := ioutil.ReadAll(f)
 				f.Close()
 				if err != nil {
-					return fmt.Errorf("error reading file at %s: %w", name, err)
+					return fmt.Errorf("error reading file at %s: %w", n, err)
 				}
 				log, err := r.Log(&git.LogOptions{FileName: &fp})
 				if err != nil {
@@ -187,7 +187,7 @@ func Diff(repo, ref1, ref2, dir string) (*EntryList, error) {
 					return err
 				}
 				entries.Append(&Entry{
-					Issue: name,
+					Issue: n,
 					Body:  string(contents),
 					Date:  lastChange.Author.When,
 					Hash:  lastChange.Hash.String(),

--- a/entry.go
+++ b/entry.go
@@ -46,11 +46,11 @@ func (el *EntryList) Append(entries ...*Entry) {
 
 // Get returns the Entry at index i
 func (el *EntryList) Get(i int) *Entry {
+	el.mu.RLock()
+	defer el.mu.RUnlock()
 	if i >= len(el.es) || i < 0 {
 		return nil
 	}
-	el.mu.RLock()
-	defer el.mu.RUnlock()
 	return el.es[i]
 }
 
@@ -74,6 +74,8 @@ func (el *EntryList) Set(i int, e *Entry) {
 
 // Len returns the number of items in the EntryList
 func (el *EntryList) Len() int {
+	el.mu.RLock()
+	defer el.mu.RUnlock()
 	return len(el.es)
 }
 

--- a/entry.go
+++ b/entry.go
@@ -5,7 +5,10 @@ import (
 	"io/ioutil"
 	"path/filepath"
 	"sort"
+	"sync"
 	"time"
+
+	"golang.org/x/sync/errgroup"
 
 	"github.com/go-git/go-billy/v5/memfs"
 	"github.com/go-git/go-git/v5"
@@ -13,11 +16,74 @@ import (
 	"github.com/go-git/go-git/v5/storage/memory"
 )
 
+// Entry is a raw changelog entry.
 type Entry struct {
 	Issue string
 	Body  string
 	Date  time.Time
 	Hash  string
+}
+
+// EntryList provides thread-safe operations on a list of Entry values
+type EntryList struct {
+	mu sync.RWMutex
+	es []*Entry
+}
+
+// NewEntryList returns an EntryList with capacity c
+func NewEntryList(c int) *EntryList {
+	return &EntryList{
+		es: make([]*Entry, 0, c),
+	}
+}
+
+// Append appends entries to the EntryList
+func (el *EntryList) Append(entries ...*Entry) {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	el.es = append(el.es, entries...)
+}
+
+// Get returns the Entry at index i
+func (el *EntryList) Get(i int) *Entry {
+	if i >= len(el.es) || i < 0 {
+		return nil
+	}
+	el.mu.RLock()
+	defer el.mu.RUnlock()
+	return el.es[i]
+}
+
+// Set sets the Entry at index i. The list will be resized if i is larger than
+// the current list capacity.
+func (el *EntryList) Set(i int, e *Entry) {
+	if i < 0 {
+		panic("invalid slice index")
+	}
+	el.mu.Lock()
+	defer el.mu.Unlock()
+
+	if i > (cap(el.es) - 1) {
+		// resize the slice
+		newEntries := make([]*Entry, i)
+		copy(newEntries, el.es)
+		el.es = newEntries
+	}
+	el.es[i] = e
+}
+
+// Len returns the number of items in the EntryList
+func (el *EntryList) Len() int {
+	return len(el.es)
+}
+
+// SortByIssue does an in-place sort of the entries by their issue number.
+func (el *EntryList) SortByIssue() {
+	el.mu.Lock()
+	defer el.mu.Unlock()
+	sort.Slice(el.es, func(i, j int) bool {
+		return el.es[i].Issue < el.es[j].Issue
+	})
 }
 
 type changelog struct {
@@ -37,7 +103,7 @@ type changelog struct {
 // exclude any entries that came before the commit date of ref1.
 //
 // Along the way, if any git or filesystem interactions fail, an error is returned.
-func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
+func Diff(repo, ref1, ref2, dir string) (*EntryList, error) {
 	r, err := git.Clone(memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL: repo,
 	})
@@ -96,37 +162,44 @@ func Diff(repo, ref1, ref2, dir string) ([]Entry, error) {
 		}
 	}
 
-	entries := make([]Entry, 0, len(entryCandidates))
+	entries := NewEntryList(len(entryCandidates))
+	errg := new(errgroup.Group)
 	for name := range entryCandidates {
-		fp := filepath.Join(dir, name)
-		f, err := wt.Filesystem.Open(fp)
-		if err != nil {
-			return nil, fmt.Errorf("error opening file at %s: %w", name, err)
+		// curry the name parameter
+		fn := func(n string) func() error {
+			return func() error {
+				fp := filepath.Join(dir, n)
+				f, err := wt.Filesystem.Open(fp)
+				if err != nil {
+					return fmt.Errorf("error opening file at %s: %w", name, err)
+				}
+				contents, err := ioutil.ReadAll(f)
+				f.Close()
+				if err != nil {
+					return fmt.Errorf("error reading file at %s: %w", name, err)
+				}
+				log, err := r.Log(&git.LogOptions{FileName: &fp})
+				if err != nil {
+					return err
+				}
+				lastChange, err := log.Next()
+				if err != nil {
+					return err
+				}
+				entries.Append(&Entry{
+					Issue: name,
+					Body:  string(contents),
+					Date:  lastChange.Author.When,
+					Hash:  lastChange.Hash.String(),
+				})
+				return nil
+			}
 		}
-		contents, err := ioutil.ReadAll(f)
-		f.Close()
-		if err != nil {
-			return nil, fmt.Errorf("error reading file at %s: %w", name, err)
-		}
-		log, err := r.Log(&git.LogOptions{FileName: &fp})
-		if err != nil {
-			return nil, err
-		}
-		lastChange, err := log.Next()
-		if err != nil {
-			return nil, err
-		}
-		entries = append(entries, Entry{
-			Issue: name,
-			Body:  string(contents),
-			Date:  lastChange.Author.When,
-			Hash:  lastChange.Hash.String(),
-		})
+		errg.Go(fn(name))
 	}
-
-	sort.Slice(entries, func(i, j int) bool {
-		return entries[i].Issue < entries[j].Issue
-	})
-
+	if err := errg.Wait(); err != nil {
+		return nil, err
+	}
+	entries.SortByIssue()
 	return entries, nil
 }


### PR DESCRIPTION
This is a follow-on to #17 for improving performance. In this part, I am refactoring the code to do the most expensive operation (traversing through the `git` log) inside a `golang.org/x/sync/errgroup.Group` which manages the work in group of goroutines executing concurrently. The entire repository is loaded into memory so there isn't contention in  doing the git operations. I did have to implement a thread-safe `EntryList` for managing the list of changelog entries created along the way, but the coordination code is all handled by `errgroup.Group` which is pretty nice. _Warning_: this is my first time using this package, so I'm still a little curious if there are any gotchas with it to be found. So far it's been really nice to work with. 

_Note_: I can't stack PRs without pushing to a remote on `hashicorp/go-changelog` and I don't have access to do that so I'll just have to get #17 merged first and then this change will only include the concurrency parts which can be merged separately. 