### PR TITLE
add basic support for configurable changelog entry types

### DIFF
--- a/types.txt
+++ b/types.txt
@@ -1,0 +1,8 @@
+enhancement
+feature
+bug
+note
+new-resource
+new-datasource
+deprecation
+breaking-change


### PR DESCRIPTION
Refs #6, but doesn't address any of the expected entry prefixes/RegEx types validation.

Configuration just uses a plain line-delimited text file for now in an effort to keep things simple and minimize dependencies, but would be open to considering HCL/JSON/YAML config parsing instead if other maintainers think that would be a reasonable direction.

Keeps the same default types for backwards compatibility, wires up custom type support into `changelog-pr-body-check` and `changelog-entry` through the `TypesValid` function, and plumbs any custom types through to the interactive type selection in `changelog-entry` too.