### PR TITLE
add changelog-check command

### DIFF
--- a/cmd/changelog-check/main.go
+++ b/cmd/changelog-check/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"io"
+	"log"
+	"os"
+
+	"github.com/hashicorp/go-changelog"
+)
+
+func main() {
+	var err error
+
+	// default to reading from stdin
+	r := os.Stdin
+
+	// read from file arg instead if provided
+	// TODO: add --help text for [file] arg handling
+	filepath := ""
+	if len(os.Args) > 1 {
+		filepath = os.Args[1]
+		r, err = os.Open(filepath)
+		if err != nil {
+			log.Fatalf("error opening %s", filepath)
+			os.Exit(1)
+		}
+	}
+
+	b, err := io.ReadAll(r)
+	if err != nil {
+		if filepath != "" {
+			log.Fatalf("error reading from %s", filepath)
+		} else {
+			log.Fatalf("error reading from stdin")
+		}
+		os.Exit(1)
+	}
+
+	entry := changelog.Entry{
+		Body: string(b),
+	}
+
+	if err := entry.Validate(); err != nil {
+		log.Fatalf(err.Error())
+		os.Exit(1)
+	}
+}

--- a/cmd/changelog-pr-body-check/main.go
+++ b/cmd/changelog-pr-body-check/main.go
@@ -48,60 +48,57 @@ func main() {
 		log.Fatalf("Error retrieving pull request github.com/"+
 			"%s/%s/%d: %s", owner, repo, prNo, err)
 	}
+
 	entry := changelog.Entry{
 		Issue: pr,
 		Body:  pullRequest.GetBody(),
 	}
-	notes := changelog.NotesFromEntry(entry)
-	if len(notes) < 1 {
-		log.Printf("no changelog entry found in %s: %s", entry.Issue,
-			string(entry.Body))
-		body := "Oops! It looks like no changelog entry is attached to" +
-			" this PR. Please include a release note block" +
-			" in the PR body, as described in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md:" +
-			"\n\n~~~\n```release-note:TYPE\nRelease note" +
-			"\n```\n~~~"
-		_, _, err = client.Issues.CreateComment(ctx, owner, repo,
-			prNo, &github.IssueComment{
-				Body: &body,
-			})
-		if err != nil {
-			log.Fatalf("Error creating pull request comment on"+
-				" github.com/%s/%s/%d: %s", owner, repo, prNo,
-				err)
+
+	if err := entry.Validate(); err != nil {
+		log.Printf("error parsing changelog entry in %s: %s", entry.Issue, err)
+		switch err.Code {
+		case changelog.EntryErrorNotFound:
+			body := "Oops! It looks like no changelog entry is attached to" +
+				" this PR. Please include a release note block" +
+				" in the PR body, as described in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md:" +
+				"\n\n~~~\n```release-note:TYPE\nRelease note" +
+				"\n```\n~~~"
+			_, _, err := client.Issues.CreateComment(ctx, owner, repo,
+				prNo, &github.IssueComment{
+					Body: &body,
+				})
+			if err != nil {
+				log.Fatalf("Error creating pull request comment on"+
+					" github.com/%s/%s/%d: %s", owner, repo, prNo,
+					err)
+			}
+			os.Exit(1)
+		case changelog.EntryErrorUnknownTypes:
+			unknownTypes := err.Details["unknownTypes"].([]string)
+
+			body := "Oops! It looks like you're using"
+			if len(unknownTypes) == 1 {
+				body += " an"
+			}
+			body += " unknown release-note type"
+			if len(unknownTypes) > 1 {
+				body += "s"
+			}
+			body += " in your changelog entries:"
+			for _, t := range unknownTypes {
+				body += "\n* " + t
+			}
+			body += "\n\nPlease only use the types listed in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md."
+			_, _, err := client.Issues.CreateComment(ctx, owner, repo,
+				prNo, &github.IssueComment{
+					Body: &body,
+				})
+			if err != nil {
+				log.Fatalf("Error creating pull request comment on"+
+					" github.com/%s/%s/%d: %s", owner, repo, prNo,
+					err)
+			}
+			os.Exit(1)
 		}
-		os.Exit(1)
-	}
-	var unknownTypes []string
-	for _, note := range notes {
-		if !changelog.TypeValid(note.Type) {
-			unknownTypes = append(unknownTypes, note.Type)
-		}
-	}
-	if len(unknownTypes) > 0 {
-		log.Printf("unknown changelog types %v", unknownTypes)
-		body := "Oops! It looks like you're using"
-		if len(unknownTypes) == 1 {
-			body += " an"
-		}
-		body += " unknown release-note type"
-		if len(unknownTypes) > 1 {
-			body += "s"
-		}
-		body += " in your changelog entries:"
-		for _, t := range unknownTypes {
-			body += "\n* " + t
-		}
-		body += "\n\nPlease only use the types listed in https://github.com/GoogleCloudPlatform/magic-modules/blob/master/.ci/RELEASE_NOTES_GUIDE.md."
-		_, _, err = client.Issues.CreateComment(ctx, owner, repo,
-			prNo, &github.IssueComment{
-				Body: &body,
-			})
-		if err != nil {
-			log.Fatalf("Error creating pull request comment on"+
-				" github.com/%s/%s/%d: %s", owner, repo, prNo,
-				err)
-		}
-		os.Exit(1)
 	}
 }

--- a/entry.go
+++ b/entry.go
@@ -76,7 +76,7 @@ func (e *Entry) Validate() *EntryValidationError {
 
 	if len(unknownTypes) > 0 {
 		return &EntryValidationError{
-			message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", unknownTypes, TypeValues()),
+			message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", unknownTypes, TypeValues),
 			Code:    EntryErrorUnknownTypes,
 			Details: map[string]interface{}{
 				"unknownTypes": unknownTypes,

--- a/entry.go
+++ b/entry.go
@@ -49,6 +49,7 @@ const (
 type EntryValidationError struct {
 	message string
 	Code    EntryErrorCode
+	Details map[string]interface{}
 }
 
 func (e *EntryValidationError) Error() string {
@@ -77,6 +78,9 @@ func (e *Entry) Validate() *EntryValidationError {
 		return &EntryValidationError{
 			message: fmt.Sprintf("unknown changelog types %v: please use only the configured changelog entry types: %v", unknownTypes, TypeValues()),
 			Code:    EntryErrorUnknownTypes,
+			Details: map[string]interface{}{
+				"unknownTypes": unknownTypes,
+			},
 		}
 	}
 


### PR DESCRIPTION
Extracted core logic from `changelog-pr-body-check` as `Entry.Validate` to expose this directly on a separate `changelog-check` command without the GitHub dependency or GCP magic modules workflow assumptions.

Intended to be implemented in conjunction with #21 to allow more flexible changelog entry validation as fitting implementers needs, but not directly dependent on it.

Refs https://github.com/hashicorp/terraform-provider-aws/issues/17135

/cc @bflad 