### PR TITLE
feat: support new-function entry types

### DIFF
--- a/cmd/changelog-build/changelog.tmpl
+++ b/cmd/changelog-build/changelog.tmpl
@@ -19,7 +19,7 @@ BREAKING CHANGES:
 {{ end -}}
 {{- end -}}
 
-{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") -}}
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") (index .NotesByType "new-function" ) -}}
 {{- if $features }}
 FEATURES:
 {{range $features | sort -}}

--- a/cmd/changelog-build/release-note.tmpl
+++ b/cmd/changelog-build/release-note.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
 {{- end -}}

--- a/cmd/changelog-entry/README.md
+++ b/cmd/changelog-entry/README.md
@@ -10,6 +10,7 @@ The type parameter can be one of the following:
 * enhancement
 * new-resource
 * new-datasource
+* new-function
 * deprecation
 * breaking-change
 * feature

--- a/cmd/changelog-pr-body-check/README.md
+++ b/cmd/changelog-pr-body-check/README.md
@@ -14,6 +14,7 @@ following types of entries:
 * enhancement
 * new-resource
 * new-datasource
+* new-function
 * deprecation
 * breaking-change
 * feature

--- a/entry.go
+++ b/entry.go
@@ -27,6 +27,7 @@ var TypeValues = []string{
 	"note",
 	"new-resource",
 	"new-datasource",
+	"new-function",
 	"deprecation",
 	"breaking-change",
 }


### PR DESCRIPTION
A `new-function` entry type will allow authors to publish changelog entries for new functions in the same manner as resources and data sources.

- https://developer.hashicorp.com/terraform/plugin/framework/functions

Closes #31 