### PR TITLE
Allow customizing allowed types for changelog-entry command

### DIFF
--- a/cmd/changelog-entry/README.md
+++ b/cmd/changelog-entry/README.md
@@ -23,6 +23,25 @@ $ changelog-entry -type improvement -subcategory monitoring -description "optimi
 
 If parameters are missing the command will prompt to fill them, the pull request number is optional and if not provided the command will try to guess it based on the current branch name and remote if the current directory is in a git repository.
 
+### Customizing the allowed types
+
+To customize the types that will be displayed in the prompt, create a line
+delimited file with the types are allow and pass it as the `-allowed-types-file`
+flag.
+
+As an example, to allow only `bug` and `enhancement` types, create a file with the following content:
+
+```sh
+bug
+enhancement
+```
+
+Then pass it to the command:
+
+```sh
+$ changelog-entry -allowed-types-file=types.txt
+```
+
 ## Output
 
 ``````markdown


### PR DESCRIPTION
Add an optional flag for the `changelog-entry` command to source the note types that are displayed in the prompt from a line delimited file.