### PR TITLE
feat: support `new-action` entry types

### DIFF
--- a/cmd/changelog-build/changelog.tmpl
+++ b/cmd/changelog-build/changelog.tmpl
@@ -19,7 +19,7 @@ BREAKING CHANGES:
 {{ end -}}
 {{- end -}}
 
-{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") (index .NotesByType "new-function" ) (index .NotesByType "new-ephemeral" ) -}}
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") (index .NotesByType "new-function" ) (index .NotesByType "new-ephemeral" ) (index .NotesByType "new-action" ) -}}
 {{- if $features }}
 FEATURES:
 {{range $features | sort -}}

--- a/cmd/changelog-build/release-note.tmpl
+++ b/cmd/changelog-build/release-note.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{else if eq "new-action" .Type}}**New Action:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
 {{- end -}}

--- a/cmd/changelog-entry/README.md
+++ b/cmd/changelog-entry/README.md
@@ -12,6 +12,7 @@ The type parameter can be one of the following:
 * new-datasource
 * new-ephemeral
 * new-function
+* new-action
 * deprecation
 * breaking-change
 * feature

--- a/cmd/changelog-pr-body-check/README.md
+++ b/cmd/changelog-pr-body-check/README.md
@@ -16,6 +16,7 @@ following types of entries:
 * new-datasource
 * new-ephemeral
 * new-function
+* new-action
 * deprecation
 * breaking-change
 * feature

--- a/entry.go
+++ b/entry.go
@@ -29,6 +29,7 @@ var TypeValues = []string{
 	"new-datasource",
 	"new-ephemeral",
 	"new-function",
+	"new-action",
 	"deprecation",
 	"breaking-change",
 }


### PR DESCRIPTION
A `new-action` entry type will allow authors to publish changelog entries for new actions in the same manner as resources, data sources, and functions.

Some AWS provider examples in the wild.


https://github.com/hashicorp/terraform-provider-aws/pull/43972
https://github.com/hashicorp/terraform-provider-aws/pull/43955
https://github.com/hashicorp/terraform-provider-aws/pull/44214
https://github.com/hashicorp/terraform-provider-aws/pull/44232
https://github.com/hashicorp/terraform-provider-aws/pull/43700