### PR TITLE
feat: support `new-list-resource` entry types

### DIFF
--- a/cmd/changelog-build/changelog.tmpl
+++ b/cmd/changelog-build/changelog.tmpl
@@ -19,7 +19,7 @@ BREAKING CHANGES:
 {{ end -}}
 {{- end -}}
 
-{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") (index .NotesByType "new-function" ) (index .NotesByType "new-ephemeral" ) (index .NotesByType "new-action" ) -}}
+{{- $features := combineTypes .NotesByType.feature (index .NotesByType "new-resource" ) (index .NotesByType "new-datasource") (index .NotesByType "new-data-source") (index .NotesByType "new-function" ) (index .NotesByType "new-ephemeral" ) (index .NotesByType "new-list-resource" ) (index .NotesByType "new-action" ) -}}
 {{- if $features }}
 FEATURES:
 {{range $features | sort -}}

--- a/cmd/changelog-build/release-note.tmpl
+++ b/cmd/changelog-build/release-note.tmpl
@@ -1,3 +1,3 @@
 {{- define "note" -}}
-{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{else if eq "new-action" .Type}}**New Action:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
+{{if eq "new-resource" .Type}}**New Resource:** {{else if eq "new-datasource" .Type}}**New Data Source:** {{else if eq "new-function" .Type}}**New Function:** {{else if eq "new-ephemeral" .Type}}**New Ephemeral Resource:** {{else if eq "new-list-resource" .Type}}**New List Resource:** {{else if eq "new-action" .Type}}**New Action:** {{ end }}{{.Body}} ([GH-{{- .Issue -}}])
 {{- end -}}

--- a/cmd/changelog-entry/README.md
+++ b/cmd/changelog-entry/README.md
@@ -11,6 +11,7 @@ The type parameter can be one of the following:
 * new-resource
 * new-datasource
 * new-ephemeral
+* new-list-resource
 * new-function
 * new-action
 * deprecation

--- a/cmd/changelog-pr-body-check/README.md
+++ b/cmd/changelog-pr-body-check/README.md
@@ -15,6 +15,7 @@ following types of entries:
 * new-resource
 * new-datasource
 * new-ephemeral
+* new-list-resource
 * new-function
 * new-action
 * deprecation

--- a/entry.go
+++ b/entry.go
@@ -28,6 +28,7 @@ var TypeValues = []string{
 	"new-resource",
 	"new-datasource",
 	"new-ephemeral",
+	"new-list-resource",
 	"new-function",
 	"new-action",
 	"deprecation",


### PR DESCRIPTION
A `new-list-resource` entry type will allow authors to publish changelog entries when list support is added for an existing resource. The convention adopted thus far amongst the major cloud providers is a `New List Resource:` entry alongside those for new resources, data sources, or ephemeral resources.
