### PR TITLE
Remove unreachable exits after fatal logs

### DIFF
--- a/cmd/changelog-check/main.go
+++ b/cmd/changelog-check/main.go
@@ -25,7 +25,6 @@ func main() {
 		r, err = os.Open(filepath)
 		if err != nil {
 			log.Fatalf("error opening %s", filepath)
-			os.Exit(1)
 		}
 	}
 
@@ -33,10 +32,8 @@ func main() {
 	if err != nil {
 		if filepath != "" {
 			log.Fatalf("error reading from %s", filepath)
-		} else {
-			log.Fatalf("error reading from stdin")
 		}
-		os.Exit(1)
+		log.Fatalf("error reading from stdin")
 	}
 
 	entry := changelog.Entry{
@@ -45,6 +42,5 @@ func main() {
 
 	if err := entry.Validate(); err != nil {
 		log.Fatalf("%s", err)
-		os.Exit(1)
 	}
 }

--- a/cmd/changelog-entry/main.go
+++ b/cmd/changelog-entry/main.go
@@ -160,9 +160,8 @@ func OpenGit(path string) (*git.Repository, error) {
 	if err != nil {
 		if path == "/" {
 			return r, err
-		} else {
-			return OpenGit(path[:strings.LastIndex(path, "/")])
 		}
+		return OpenGit(path[:strings.LastIndex(path, "/")])
 	}
 	return r, err
 }


### PR DESCRIPTION
Drop redundant os.Exit calls that immediately followed log.Fatalf, and simplify else blocks where the preceding branch already exits or returns.